### PR TITLE
Fixed getTransactionReference

### DIFF
--- a/src/Message/AIMResponse.php
+++ b/src/Message/AIMResponse.php
@@ -53,6 +53,6 @@ class AIMResponse extends AbstractResponse
 
     public function getTransactionReference()
     {
-        return $this->data[6];
+        return $this->data[37];
     }
 }


### PR DESCRIPTION
see http://www.authorize.net/support/AIM_guide.pdf "Section 'Fields in the Payment Gateway
Response' - 

37 Purchase Order
Number
Value: The merchant-assigned purchase order number
Format: 25-character maximum (no symbols)
